### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,13 @@ targetCompatibility = 1.8
 
 dependencies {
 	implementation 'org.slf4j:slf4j-api:1.7.25'
-	implementation 'com.google.guava:guava:30.1-jre'
-	implementation 'org.jctools:jctools-core:2.1.1'
+	implementation 'com.google.guava:guava:31.0.1-jre'
+	implementation 'org.jctools:jctools-core:3.3.0'
 	implementation 'com.carrotsearch:hppc:0.7.3'
 	implementation 'org.apache.commons:commons-math3:3.6.1'
 	implementation 'org.hamcrest:hamcrest-library:1.3'
 	
-	testImplementation 'junit:junit:4.13'
+	testImplementation 'junit:junit:4.13.2'
 	testImplementation 'ch.qos.logback:logback-classic:1.1.7'
 }
 


### PR DESCRIPTION
Some dependencies can be updated to newer versions without breaking anything (at least in the tests). Especially, it would be nice if jctools is the same version as in Kieker. 