### PR TITLE
Update to Guava 31.1 to avoid security problem

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ targetCompatibility = 1.8
 
 dependencies {
 	implementation 'org.slf4j:slf4j-api:1.7.25'
-	implementation 'com.google.guava:guava:31.0.1-jre'
+	implementation 'com.google.guava:guava:31.1-jre'
 	implementation 'org.jctools:jctools-core:3.3.0'
 	implementation 'com.carrotsearch:hppc:0.7.3'
 	implementation 'org.apache.commons:commons-math3:3.6.1'


### PR DESCRIPTION
Guava 31.0.1 contains a security problem (https://ossindex.sonatype.org/vulnerability/sonatype-2020-0926?component-type=maven&component-name=com.google.guava%2Fguava&utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0), so I would recommend to update to 31.1.