### PR TITLE
Use binary wrapper, since sample code is not needed

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Using the `-all` wrapper is not needed, since we do not need documentation and sample code here (https://docs.gradle.org/current/userguide/gradle_wrapper.html). Therefore, we I would recommend to switch to the `-bin` variant.