### PR TITLE
Add dependabot and update to guava 31.1.3-jre to fix security vulnerability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle" 
+    directory: "/" 
+    schedule:
+      interval: "weekly"
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ targetCompatibility = 1.8
 
 dependencies {
 	implementation 'org.slf4j:slf4j-api:1.7.25'
-	implementation 'com.google.guava:guava:31.0.1-jre'
+	implementation 'com.google.guava:guava:32.1.3-jre'
 	implementation 'org.jctools:jctools-core:3.3.0'
 	implementation 'com.carrotsearch:hppc:0.7.3'
 	implementation 'org.apache.commons:commons-math3:3.6.1'


### PR DESCRIPTION
TeaTime is currently shipped with Guava 31.0.1, which has one high and one low security vulnerability: https://ossindex.sonatype.org/component/pkg:maven/com.google.guava/guava@31.0.1-jre?utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0 this should be fixed directly.

To avoid such problems in the future, TeaTime should use dependabot.