### PR TITLE
Add basic test workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,33 @@
+name: Basic TeeTime Build
+
+on: pull_request
+
+jobs:
+  build:
+    strategy: 
+        matrix:
+          os: [ubuntu-latest, windows-latest, macos-latest]
+          java: [ 11, 17, 21 ]
+        fail-fast: false
+    runs-on: ${{ matrix.os }}
+    name: Java ${{ matrix.java }} OS ${{ matrix.os }} sample
+    steps:
+    - name: Set Git Property and output path
+      run: |
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          git config --system core.longpaths true
+        fi
+      shell: bash
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Run Unit Tests
+      run: ./gradlew test
+    - name: Upload Unit Test Results
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Unit Test Results (Java ${{ matrix.java }} OS ${{ matrix.os }})
+        path: '**/build/test-results/test/TEST-*.xml'


### PR DESCRIPTION
Currently, TeeTime does not compile due to compilation errors (probably after dependabot updates):

> > Task :compileJava FAILED                                                                                                                                                               
> /home/reichelt/nvme/workspaces/kiekerworkspace/TeeTime/src/main/java/teetime/framework/pipe/AbstractSynchedPipe.java:21: error: cannot find symbol                                       
> import org.jctools.queues.QueueFactory;                                                     
>                          ^                                                                                                                                                               
>   symbol:   class QueueFactory                                                              
>   location: package org.jctools.queues                                                                                                                                                   
> /home/reichelt/nvme/workspaces/kiekerworkspace/TeeTime/src/main/java/teetime/framework/pipe/AbstractSynchedPipe.java:22: error: package org.jctools.queues.spec does not exist           
> import org.jctools.queues.spec.ConcurrentQueueSpec;                                                                                                                                      
>                               ^
> /home/reichelt/nvme/workspaces/kiekerworkspace/TeeTime/src/main/java/teetime/framework/pipe/AbstractSynchedPipe.java:23: error: package org.jctools.queues.spec does not exist
> import org.jctools.queues.spec.Ordering;
>                               ^
> /home/reichelt/nvme/workspaces/kiekerworkspace/TeeTime/src/main/java/teetime/framework/pipe/AbstractSynchedPipe.java:24: error: package org.jctools.queues.spec does not exist
> import org.jctools.queues.spec.Preference;
>                               ^
> /home/reichelt/nvme/workspaces/kiekerworkspace/TeeTime/src/main/java/teetime/framework/pipe/UnboundedSynchedPipe.java:20: error: cannot find symbol
> import org.jctools.queues.QueueFactory;
>                          ^

To avoid this in the future, we should build TeeTime for every PR, and than only merge the dependabot updates that work.